### PR TITLE
Minor fix to compile on macOS

### DIFF
--- a/quick+/system/global.h
+++ b/quick+/system/global.h
@@ -11,9 +11,8 @@
 #include <cstring>
 #include <stack>
 #include <bits/stdc++.h>
-// If not Linux (e.g. Windows), include direct.h because it doesn't work in Linux.
-#ifndef __linux__
-#include <direct.h>
+#ifdef _WIN32
+#include <direct.h>     // Include direct.h only for Windows
 #endif
 
 #define hash_map __gnu_cxx::hash_map // ??
@@ -116,11 +115,11 @@ float log_time(const string msg, const timepoint start_time, const float latest_
 // Disk operations
 void make_directory(const char *name)
 {
-#ifdef __linux__ // check if linux
-	mkdir(name, S_IRWXU);
+#ifdef _WIN32
+    // Works on Windows when include direct.h, but direct.h doesn't work on linux as it was "provided by Microsoft Windows".
+    _mkdir(name);
 #else
-	// Works on Windows when inclue direct.h, but direct.h doesn't work on linux as it was "provided by Microsoft Windows".
-	_mkdir(name); 
+    mkdir(name, S_IRWXU);  // POSIX-compliant
 #endif
 }
 


### PR DESCRIPTION
This fixes an issue that prevented the quick+ artifact from
compiling on macOS. It still compiles fine on Linux. Didn't check
if it compiles on Windows, but I believe it should.

Note there are still some warnings.

PS: Note that on macOS, g++ points to the default compiler (clang)
which fails to compile the quick+ artifact. My solution was to
change the Makefile to use g++-14 (installed via homebrew).
